### PR TITLE
adding remove cookie _gat for Google analytics

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -135,6 +135,7 @@ sub vcl_recv {
   # Remove any Google Analytics based cookies
   set req.http.Cookie = regsuball(req.http.Cookie, "__utm.=[^;]+(; )?", "");
   set req.http.Cookie = regsuball(req.http.Cookie, "_ga=[^;]+(; )?", "");
+  set req.http.Cookie = regsuball(req.http.Cookie, "_gat=[^;]+(; )?", "");
   set req.http.Cookie = regsuball(req.http.Cookie, "utmctr=[^;]+(; )?", "");
   set req.http.Cookie = regsuball(req.http.Cookie, "utmcmd.=[^;]+(; )?", "");
   set req.http.Cookie = regsuball(req.http.Cookie, "utmccn.=[^;]+(; )?", "");


### PR DESCRIPTION
I have recently seen _gat cookie being used which was stopping cache_hits for me
